### PR TITLE
More Tantares engine configs

### DIFF
--- a/GameData/RealFuels/Stockalike_Tantares.cfg
+++ b/GameData/RealFuels/Stockalike_Tantares.cfg
@@ -1324,3 +1324,1726 @@
 
 
 }
+@PART[ALV_Engine_A]:NEEDS[!Tantares_RF_Stockalike]:FOR[RealFuels_StockEngines] //ALV-A Booster
+{
+  @title = ALV-A Booster
+  @mass = 3.416
+  @cost = 7758
+  %entryCost = 38790
+  @maxTemp = 2244
+  @description = A large booster, ideal for first stages.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 2500
+    @heatProduction = 170
+    @atmosphereCurve
+    {
+      @key,0 = 0 337
+      @key,1 = 1 277
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 5
+    origTechLevel = 5
+    engineType = L+
+    origMass = 3.416
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 2500
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 25
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen
+      maxThrust = 2500
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.0300
+      IspV = 1.0300
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 25
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 1875
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3000
+      IspV = 1.2700
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 25
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 2375
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+      }
+      IspSL = 0.9300
+      IspV = 0.9300
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 25
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Kerosene+HTP
+      maxThrust = 2500
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 18
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 82
+      }
+      IspSL = 0.9200
+      IspV = 0.9200
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 25
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 25
+    }
+  }
+  
+  
+}
+@PART[ALV_Engine_B]:NEEDS[!Tantares_RF_Stockalike]:FOR[RealFuels_StockEngines] //ALV-B Booster
+{
+  @title = ALV-B Booster
+  @mass = 1.776
+  @cost = 4070
+  %entryCost = 20350
+  @maxTemp = 2244
+  @description = Four nozzles are better than one! Eight nozzles are better than four, but we're not made of money.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 1300
+    @heatProduction = 170
+    @atmosphereCurve
+    {
+      @key,0 = 0 337
+      @key,1 = 1 277
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 5
+    origTechLevel = 5
+    engineType = L+
+    origMass = 1.776
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 1300
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 13
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen
+      maxThrust = 1300
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.0300
+      IspV = 1.0300
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 13
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 975
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3000
+      IspV = 1.2700
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 13
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 1235
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+      }
+      IspSL = 0.9300
+      IspV = 0.9300
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 13
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Kerosene+HTP
+      maxThrust = 1300
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 18
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 82
+      }
+      IspSL = 0.9200
+      IspV = 0.9200
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 13
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 13
+    }
+  }
+  
+  
+}
+@PART[ALV_Engine_C]:NEEDS[!Tantares_RF_Stockalike]:FOR[RealFuels_StockEngines] //ALV-C Booster
+{
+  @title = ALV-C Booster
+  @mass = 1.54
+  @cost = 1693
+  %entryCost = 8465
+  @maxTemp = 1549
+  @description = A capable upper stage engine. A set of MonoPropellant thrusters are in-built, for fine orbit adjustments.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 390
+    @heatProduction = 98
+    @atmosphereCurve
+    {
+      @key,0 = 0 375
+      @key,1 = 1 121
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Aerozine50
+      ratio = 50.173010
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 49.826990
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 5
+    origTechLevel = 5
+    engineType = U+
+    origMass = 1.54
+    configuration = Aerozine50+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 390
+      heatProduction = 98
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.9600
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.9
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      maxThrust = 390
+      heatProduction = 98
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 46.60730931181897
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 53.39269068818103
+      }
+      IspSL = 0.9500
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.9
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 390
+      heatProduction = 98
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.135562138524485
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.864437861475515
+      }
+      IspSL = 0.9600
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.9
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 371
+      heatProduction = 98
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+      }
+      IspSL = 0.9300
+      IspV = 1.0230
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.9
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 293
+      heatProduction = 98
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3000
+      IspV = 1.3970
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.9
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 3.9
+    }
+  }
+  
+  
+}
+@PART[TLV_Engine_A]:NEEDS[!Tantares_RF_Stockalike]:FOR[RealFuels_StockEngines] //Tavio CEM(b)
+{
+  @title = Tavio CEM(b)
+  @mass = 1.288
+  @cost = 1170
+  %entryCost = 5850
+  @maxTemp = 1478
+  @description = The CEM(b) is among the most powerful engines in its size category. Rumours that the name stands for "Civilian Edition of Missile Booster" have been thoroughly refuted.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 300
+    @heatProduction = 96
+    @atmosphereCurve
+    {
+      @key,0 = 0 364
+      @key,1 = 1 117
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Aerozine50
+      ratio = 50.173010
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 49.826990
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 3
+    origTechLevel = 3
+    engineType = U+
+    origMass = 1.288
+    configuration = Aerozine50+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 300
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.9600
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      maxThrust = 300
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 46.60730931181897
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 53.39269068818103
+      }
+      IspSL = 0.9500
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 300
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.135562138524485
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.864437861475515
+      }
+      IspSL = 0.9600
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 285
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+      }
+      IspSL = 0.9300
+      IspV = 1.0230
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 225
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3000
+      IspV = 1.3970
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 3
+    }
+  }
+  
+  
+}
+@PART[TLV_Engine_B]:NEEDS[!Tantares_RF_Stockalike]:FOR[RealFuels_StockEngines] //Tavio CEM(u)
+{
+  @title = Tavio CEM(u)
+  @mass = 2.4
+  @cost = 1250
+  %entryCost = 6250
+  @maxTemp = 1538
+  @description = The CEM(u) might seem underpowered compared to its less flamboyant brother. But, increased efficiency and a higher degree of thrust vectoring lets it fill some kind of niche.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 190
+    @heatProduction = 102
+    @atmosphereCurve
+    {
+      @key,0 = 0 397
+      @key,1 = 1 129
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Aerozine50
+      ratio = 50.173010
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 49.826990
+    }
+  }
+  MODULE
+  {
+    name = ModuleGimbal
+    gimbalTransformName = thrustTransform
+    gimbalRange = 1
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 3
+    origTechLevel = 3
+    engineType = U+
+    origMass = 2.4
+    configuration = Aerozine50+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 190
+      heatProduction = 102
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 1.0560
+      IspV = 1.1400
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.9
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      maxThrust = 190
+      heatProduction = 102
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 46.60730931181897
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 53.39269068818103
+      }
+      IspSL = 1.0450
+      IspV = 1.1400
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.9
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 190
+      heatProduction = 102
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.135562138524485
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.864437861475515
+      }
+      IspSL = 1.0560
+      IspV = 1.1400
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.9
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 181
+      heatProduction = 102
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+      }
+      IspSL = 1.0230
+      IspV = 1.1160
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.9
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 143
+      heatProduction = 102
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.4300
+      IspV = 1.5240
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.9
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 1.9
+    }
+  }
+  
+  
+}
+@PART[Almach_Engine_C]:NEEDS[!Tantares_RF_Stockalike]:FOR[RealFuels_StockEngines] //Almach_Engine_C
+{
+  @title = "Waykeeper" V4 Engine
+  @mass = 0.32
+  @cost = 164
+  %entryCost = 820
+  @maxTemp = 1654
+  @description = The "Waykeeper" engine is primarily designed to compliment a much larger engine. Featuring a high-gimballed nozzle, it is useful for keeping a spacecraft on the straight and narrow.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 9
+    @heatProduction = 145
+    @atmosphereCurve
+    {
+      @key,0 = 0 380
+      @key,1 = 1 213
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Aerozine50
+      ratio = 50.173010
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 49.826990
+    }
+  }
+  MODULE
+  {
+    name = ModuleGimbal
+    gimbalTransformName = thrustTransform
+    gimbalRange = 4
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 1
+    origTechLevel = 1
+    engineType = U
+    origMass = 0.32
+    configuration = Aerozine50+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 9
+      heatProduction = 145
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 1.1520
+      IspV = 1.2350
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.09
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      maxThrust = 9
+      heatProduction = 145
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 46.60730931181897
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 53.39269068818103
+      }
+      IspSL = 1.1400
+      IspV = 1.2350
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.09
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 9
+      heatProduction = 145
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.135562138524485
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.864437861475515
+      }
+      IspSL = 1.1520
+      IspV = 1.2350
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.09
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 9
+      heatProduction = 145
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+      }
+      IspSL = 1.1160
+      IspV = 1.2090
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.09
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 7
+      heatProduction = 145
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.5600
+      IspV = 1.6510
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.09
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.09
+    }
+  }
+  
+  
+}
+@PART[Polaris_Engine_A]:NEEDS[!Tantares_RF_Stockalike]:FOR[RealFuels_StockEngines] //TE-5 Orbital Motor
+{
+  @title = TE-5 Orbital Motor
+  @mass = 0.69
+  @cost = 289
+  %entryCost = 1445
+  @maxTemp = 1450
+  @description = The TE-5's incredibly simplistic design hides the fact that is is a very capable, and efficient, orbital engine.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 40
+    @heatProduction = 55
+    @atmosphereCurve
+    {
+      @key,0 = 0 388
+      @key,1 = 1 53
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Aerozine50
+      ratio = 50.173010
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 49.826990
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 1
+    origTechLevel = 1
+    engineType = O
+    origMass = 0.69
+    configuration = Aerozine50+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 40
+      heatProduction = 55
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.4800
+      IspV = 1.2350
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.4
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = HTP
+      maxThrust = 36
+      heatProduction = 55
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.0885
+      IspV = 0.6045
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.4
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 40
+      heatProduction = 55
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.1370
+      IspV = 0.9360
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.4
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.4
+    }
+  }
+  
+  
+}
+@PART[Almach_Engine_B]:NEEDS[!Tantares_RF_Stockalike]:FOR[RealFuels_StockEngines] //"Waymaker" V4 Engine
+{
+  @title = "Waymaker" V4 Engine
+  @mass = 0.272
+  @cost = 189
+  %entryCost = 945
+  @maxTemp = 1450
+  @description = The "Waymaker" is a small engine designed for upper stages.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 60
+    @heatProduction = 55
+    @atmosphereCurve
+    {
+      @key,0 = 0 328
+      @key,1 = 1 53
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Aerozine50
+      ratio = 50.173010
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 49.826990
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 1
+    origTechLevel = 1
+    engineType = O
+    origMass = 0.272
+    configuration = Aerozine50+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 60
+      heatProduction = 55
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.4800
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.6
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = HTP
+      maxThrust = 54
+      heatProduction = 55
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.0885
+      IspV = 0.5115
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.6
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      maxThrust = 60
+      heatProduction = 55
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 46.60730931181897
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 53.39269068818103
+      }
+      IspSL = 0.4750
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.6
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.6
+    }
+  }
+
+
+}


### PR DESCRIPTION
Adds a few more engine configs that seem to have been missed. Mostly upper-stage and orbital maneuver engines. Created using the web app. Thrust and ISP based off of the originals with mass decreased to compensate. 

For your consideration.